### PR TITLE
Improve mobile invoice layout and stabilize editor state

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,196 @@
     .dark ::-webkit-scrollbar-track { background: #1e293b; }
     .dark ::-webkit-scrollbar-thumb { background: #475569; }
     .dark ::-webkit-scrollbar-thumb:hover { background: #64748b; }
+
+    .mobile-only { display: none; }
+
+    body.is-mobile-width .mobile-only,
+    body.is-mobile-preview .mobile-only { display: block; }
+
+    body.is-mobile-width #items,
+    body.is-mobile-preview #items { display: block; border: none; }
+
+    body.is-mobile-width #itemsWrapper,
+    body.is-mobile-preview #itemsWrapper {
+      border: none;
+      background: transparent;
+      overflow: visible;
+      padding: 0;
+    }
+
+    body.is-mobile-width #items thead,
+    body.is-mobile-preview #items thead { display: none; }
+
+    body.is-mobile-width #items tbody,
+    body.is-mobile-preview #items tbody { display: grid; gap: 1rem; }
+
+    body.is-mobile-width #items tbody tr,
+    body.is-mobile-preview #items tbody tr {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 1rem;
+      border-radius: 1rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background-color: rgba(248, 250, 252, 0.95);
+      box-shadow: 0 22px 45px -28px rgba(15, 23, 42, 0.55);
+    }
+
+    html.dark body.is-mobile-width #items tbody tr,
+    html.dark body.is-mobile-preview #items tbody tr {
+      background-color: rgba(15, 23, 42, 0.72);
+      border-color: rgba(71, 85, 105, 0.65);
+      box-shadow: 0 22px 45px -28px rgba(15, 23, 42, 0.8);
+    }
+
+    body.is-mobile-width #items tbody tr td.item-cell,
+    body.is-mobile-preview #items tbody tr td.item-cell { padding: 0; border-bottom: none; }
+
+    body.is-mobile-width #items tbody tr td.item-cell--desc input,
+    body.is-mobile-preview #items tbody tr td.item-cell--desc input {
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
+
+    body.is-mobile-width #items tbody tr td.item-cell--qty,
+    body.is-mobile-preview #items tbody tr td.item-cell--qty,
+    body.is-mobile-width #items tbody tr td.item-cell--rate,
+    body.is-mobile-preview #items tbody tr td.item-cell--rate,
+    body.is-mobile-width #items tbody tr td.item-cell--amount,
+    body.is-mobile-preview #items tbody tr td.item-cell--amount {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: #475569;
+    }
+
+    html.dark body.is-mobile-width #items tbody tr td.item-cell--qty,
+    html.dark body.is-mobile-preview #items tbody tr td.item-cell--qty,
+    html.dark body.is-mobile-width #items tbody tr td.item-cell--rate,
+    html.dark body.is-mobile-preview #items tbody tr td.item-cell--rate,
+    html.dark body.is-mobile-width #items tbody tr td.item-cell--amount,
+    html.dark body.is-mobile-preview #items tbody tr td.item-cell--amount { color: #e2e8f0; }
+
+    body.is-mobile-width #items tbody tr td.item-cell--qty input,
+    body.is-mobile-preview #items tbody tr td.item-cell--qty input,
+    body.is-mobile-width #items tbody tr td.item-cell--rate input,
+    body.is-mobile-preview #items tbody tr td.item-cell--rate input {
+      flex: 1;
+      text-align: right;
+      background-color: transparent;
+    }
+
+    body.is-mobile-width #items tbody tr td.item-cell--amount .item-cell__value,
+    body.is-mobile-preview #items tbody tr td.item-cell--amount .item-cell__value {
+      font-weight: 700;
+      color: #0f172a;
+    }
+
+    html.dark body.is-mobile-width #items tbody tr td.item-cell--amount .item-cell__value,
+    html.dark body.is-mobile-preview #items tbody tr td.item-cell--amount .item-cell__value { color: #f8fafc; }
+
+    body.is-mobile-width #items tbody tr td.item-cell--actions,
+    body.is-mobile-preview #items tbody tr td.item-cell--actions { align-self: flex-end; }
+
+    body.is-mobile-width #items tbody tr td.item-cell--actions button,
+    body.is-mobile-preview #items tbody tr td.item-cell--actions button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.25rem;
+      height: 2.25rem;
+      border-radius: 9999px;
+      background-color: rgba(248, 113, 113, 0.12);
+      color: #dc2626;
+    }
+
+    html.dark body.is-mobile-width #items tbody tr td.item-cell--actions button,
+    html.dark body.is-mobile-preview #items tbody tr td.item-cell--actions button {
+      background-color: rgba(239, 68, 68, 0.18);
+      color: #fca5a5;
+    }
+
+    body.is-mobile-width #items tbody tr td[data-label]::before,
+    body.is-mobile-preview #items tbody tr td[data-label]::before {
+      content: attr(data-label);
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #94a3b8;
+    }
+
+    html.dark body.is-mobile-width #items tbody tr td[data-label]::before,
+    html.dark body.is-mobile-preview #items tbody tr td[data-label]::before { color: #cbd5f5; }
+
+    .subitem-stack {
+      margin-top: 0.75rem;
+      padding-left: 1rem;
+      border-left: 2px solid #e2e8f0;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    html.dark .subitem-stack { border-color: #475569; }
+
+    body.is-mobile-width .subitem-stack,
+    body.is-mobile-preview .subitem-stack {
+      padding-left: 0;
+      border-left: none;
+    }
+
+    .subitem-card {
+      border-radius: 0.75rem;
+      border: 1px solid #e2e8f0;
+      background-color: rgba(248, 250, 252, 0.95);
+      padding: 0.75rem;
+      box-shadow: 0 14px 40px -28px rgba(15, 23, 42, 0.55);
+    }
+
+    html.dark .subitem-card {
+      border-color: rgba(71, 85, 105, 0.65);
+      background-color: rgba(15, 23, 42, 0.7);
+      box-shadow: 0 14px 40px -28px rgba(15, 23, 42, 0.82);
+    }
+
+    .subitem-card__header {
+      display: flex;
+      gap: 0.5rem;
+      align-items: flex-start;
+    }
+
+    .subitem-card__grid {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+
+    body.is-mobile-width .subitem-card__grid,
+    body.is-mobile-preview .subitem-card__grid { grid-template-columns: 1fr !important; }
+
+    .subitem-card__field {
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .subitem-card__label {
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: #94a3b8;
+    }
+
+    html.dark .subitem-card__label { color: #cbd5f5; }
+
+    .subitem-card__value {
+      font-weight: 700;
+      color: #0f172a;
+    }
+
+    html.dark .subitem-card__value { color: #f8fafc; }
   </style>
 </head>
 <body class="bg-slate-100 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans transition-colors duration-300">
@@ -135,9 +325,9 @@
 
         <!-- Header Section -->
         <header class="pb-6 border-b border-slate-200 dark:border-slate-700 print-border-none">
-          <div class="flex flex-wrap items-center justify-between gap-6">
+          <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
             <!-- Brand Info -->
-            <div class="flex items-center gap-4 no-print">
+            <div class="flex items-start gap-4 no-print md:items-center">
               <img id="ui-logo" src="https://placehold.co/80x80/b8860b/FFFFFF?text=OAK" alt="Company Logo" class="w-20 h-20 h-auto object-contain bg-slate-100 dark:bg-slate-700 rounded-lg">
               <div>
                 <h2 class="text-lg font-bold text-slate-900 dark:text-white">OAK Builders LLC</h2>
@@ -146,28 +336,28 @@
               </div>
             </div>
             <!-- Document Type -->
-            <div class="flex items-center gap-3">
+            <div class="flex items-center gap-3 self-start md:self-auto">
               <h1 id="docTitle" class="text-2xl font-bold tracking-tight text-slate-900 dark:text-white print:text-4xl print:text-gray-800">Invoice</h1>
               <select id="docType" class="no-print bg-slate-100 dark:bg-slate-700 border-slate-300 dark:border-slate-600 rounded-lg text-sm focus:ring-accent focus:border-accent"></select>
             </div>
           </div>
-          
+
           <!-- Toolbar -->
-          <div class="no-print mt-6 flex flex-wrap items-center justify-between gap-4">
-              <div class="flex items-center gap-2">
+          <div class="no-print mt-6 flex flex-col gap-4 md:flex-row md:flex-wrap md:items-center md:justify-between">
+              <div class="flex flex-wrap items-center gap-2 w-full md:w-auto">
                 <input id="filePicker" type="file" accept=".xlsx" class="hidden" />
                 <button data-action="loadExcel" class="px-4 py-2 text-sm font-semibold bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors">Load from Excel</button>
                 <button data-action="saveExcel" class="px-4 py-2 text-sm font-semibold text-slate-900 bg-accent hover:bg-accent-light rounded-lg transition-colors">Save to Excel</button>
               </div>
-              <div class="flex items-center gap-2">
-                 <div class="flex items-center gap-2">
+              <div class="flex flex-wrap items-center gap-3 w-full md:w-auto">
+                 <div class="flex items-center gap-2 flex-wrap">
                     <label for="stampType" class="text-xs font-semibold text-slate-500">PDF Stamp</label>
                     <select id="stampType" class="bg-slate-100 dark:bg-slate-700 border-slate-300 dark:border-slate-600 rounded-lg text-sm focus:ring-accent focus:border-accent"></select>
                  </div>
                  <button onclick="window.print()" class="px-4 py-2 text-sm font-semibold bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors">Print / PDF</button>
-                 
+
                  <!-- View Mode Switcher -->
-                 <div class="ml-2 flex items-center gap-1 p-1 bg-slate-200 dark:bg-slate-700 rounded-lg">
+                 <div class="ml-0 md:ml-2 flex items-center gap-1 p-1 bg-slate-200 dark:bg-slate-700 rounded-lg">
                     <button data-action="setView" data-view="pc" class="p-2 rounded-md transition-colors" title="PC View">
                         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M13.5 0H2.5A1.5 1.5 0 0 0 1 1.5v8A1.5 1.5 0 0 0 2.5 11h3.5v2H5a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-1v-2h3.5A1.5 1.5 0 0 0 15 9.5v-8A1.5 1.5 0 0 0 13.5 0zM2 1.5a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 .5.5v8a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-8z"/></svg>
                     </button>
@@ -188,7 +378,7 @@
         </header>
 
         <!-- Main Content -->
-        <main class="mt-8">
+        <main class="mt-8 pb-48 md:pb-0">
           <div class="flex flex-col md:flex-row justify-between gap-8">
               
               <!-- Bill To Section -->
@@ -244,7 +434,7 @@
 
           <!-- Items Table -->
           <section class="mt-10">
-            <div class="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700 print-border-none">
+            <div id="itemsWrapper" class="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700 print-border-none">
               <table class="w-full" id="items">
                 <thead class="bg-slate-50 dark:bg-slate-700/50 text-xs uppercase text-slate-500 dark:text-slate-400 print:bg-gray-200 print:text-gray-600">
                   <tr>
@@ -281,7 +471,7 @@
               </div>
             </div>
             <!-- Totals Section -->
-            <div class="space-y-4 totals-section">
+            <div class="space-y-4 totals-section rounded-2xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 p-6 print:bg-transparent print:border-0 print:p-0">
                <div class="space-y-2">
                     <div class="flex justify-between items-center">
                         <span class="text-slate-500 dark:text-slate-400 print:text-gray-600">Subtotal</span>
@@ -324,7 +514,43 @@
           </section>
 
         </main>
-        
+
+        <!-- Mobile Action Bar -->
+        <div class="mobile-only no-print">
+          <div class="fixed inset-x-0 bottom-0 px-4 pb-6 pointer-events-none z-40">
+            <div class="pointer-events-auto mx-auto max-w-md rounded-3xl border border-slate-200 dark:border-slate-700 bg-white/90 backdrop-blur dark:bg-slate-800/90 shadow-2xl p-4 space-y-4">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Balance Due</p>
+                  <p id="mobile-balance" class="text-2xl font-bold text-slate-900 dark:text-white">$0.00</p>
+                </div>
+                <div class="flex gap-2">
+                  <button data-action="saveExcel" class="px-4 py-2 text-sm font-semibold text-slate-900 bg-accent hover:bg-accent-light rounded-full shadow-sm transition-colors">Save</button>
+                  <button type="button" onclick="window.print()" class="px-4 py-2 text-sm font-semibold bg-slate-900 text-white dark:bg-slate-200 dark:text-slate-900 rounded-full shadow-sm transition-colors">PDF</button>
+                </div>
+              </div>
+              <div class="grid grid-cols-3 gap-3 text-xs text-slate-500 dark:text-slate-400">
+                <div>
+                  <p class="font-semibold uppercase tracking-wider text-[0.65rem]">Subtotal</p>
+                  <p id="mobile-subtotal" class="text-sm font-semibold text-slate-900 dark:text-white">$0.00</p>
+                </div>
+                <div>
+                  <p class="font-semibold uppercase tracking-wider text-[0.65rem]">Tax</p>
+                  <p id="mobile-tax" class="text-sm font-semibold text-slate-900 dark:text-white">$0.00</p>
+                </div>
+                <div>
+                  <p class="font-semibold uppercase tracking-wider text-[0.65rem]">Paid</p>
+                  <p id="mobile-paid" class="text-sm font-semibold text-slate-900 dark:text-white">$0.00</p>
+                </div>
+              </div>
+              <div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                <span class="font-semibold uppercase tracking-wider text-[0.65rem]">Total</span>
+                <span id="mobile-total" class="text-base font-semibold text-slate-900 dark:text-white">$0.00</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- START: Print-Only Footer -->
         <div class="hidden print-only-block mt-24 pt-8 border-t border-gray-300 text-xs text-gray-600">
             <div class="grid grid-cols-3 gap-8">
@@ -380,6 +606,10 @@ document.addEventListener('DOMContentLoaded', () => {
         return dt.toISOString().slice(0, 10);
     };
 
+    const createEmptyItem = () => ({ desc: '', qty: 1, rate: 0, usesSub: false, subs: [] });
+    const createEmptySubItem = () => ({ desc: '', qty: 1, rate: 0 });
+    const createEmptyPayment = () => ({ date: todayISO(), amount: 0, method: 'New Payment' });
+
     // Safe localStorage access to avoid crashes in private mode or blocked storage
     const storage = {
         get(key) {
@@ -406,7 +636,7 @@ document.addEventListener('DOMContentLoaded', () => {
             showPaymentTracker: false,
             billTo: '',
             notes: 'Thanks for your business.',
-            items: [{ desc: '', qty: 1, rate: 0, usesSub: false, subs: [] }],
+            items: [createEmptyItem()],
             adjustments: [
                 { id: 'bond', label: 'Bond', enabled: false, pct: 10 },
                 { id: 'oh', label: 'Overhead', enabled: false, pct: 15 },
@@ -426,23 +656,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function normalizeItem(it) {
-        if (!it || typeof it !== 'object') return { desc: '', qty: 1, rate: 0, usesSub: false, subs: [] };
-        return {
-            desc: String(it.desc ?? ''),
-            qty: toNum(it.qty),
-            rate: toNum(it.rate),
-            usesSub: truthy(it.usesSub),
-            subs: Array.isArray(it.subs) ? it.subs.map(s => ({
-                desc: String(s?.desc ?? ''),
-                qty: toNum(s?.qty),
-                rate: toNum(s?.rate)
-            })) : []
-        };
+        const base = createEmptyItem();
+        if (!it || typeof it !== 'object') return base;
+        base.desc = String(it.desc ?? '');
+        base.qty = toNum(it.qty);
+        base.rate = toNum(it.rate);
+        base.usesSub = truthy(it.usesSub);
+        base.subs = Array.isArray(it.subs) ? it.subs.map(s => ({
+            ...createEmptySubItem(),
+            desc: String(s?.desc ?? ''),
+            qty: toNum(s?.qty),
+            rate: toNum(s?.rate)
+        })) : [];
+        return base;
     }
 
     function normalizeState() {
         if (!Array.isArray(state.items) || state.items.length === 0) {
-            state.items = [{ desc: '', qty: 1, rate: 0, usesSub: false, subs: [] }];
+            state.items = [createEmptyItem()];
         }
         state.items = state.items.map(it => normalizeItem(it));
         if (!Array.isArray(state.payments)) {
@@ -499,38 +730,61 @@ document.addEventListener('DOMContentLoaded', () => {
         const tbody = $('#items tbody');
         tbody.innerHTML = state.items.map((it, idx) => `
             <tr class="border-b border-slate-200 dark:border-slate-700 last:border-b-0 print:border-gray-300">
-                <td class="px-4 py-3 align-top">
-                    <input class="w-full bg-transparent focus:outline-none" placeholder="Item description" value="${it.desc}" data-idx="${idx}" data-field="desc">
-                    ${it.usesSub ? renderSubItems(it, idx) : ''}
-                    <div class="no-print mt-2">
-                        <label class="flex items-center gap-2 text-xs text-slate-500 cursor-pointer">
-                            <input type="checkbox" ${it.usesSub ? 'checked' : ''} class="rounded text-accent focus:ring-accent/50" data-idx="${idx}" data-action="toggleSub">
-                            Use sub-items
-                        </label>
+                <td class="item-cell item-cell--desc px-4 py-3 align-top">
+                    <div class="space-y-3">
+                        <input class="w-full bg-transparent focus:outline-none text-sm md:text-base" placeholder="Item description" value="${it.desc}" data-idx="${idx}" data-field="desc">
+                        ${it.usesSub ? renderSubItems(it, idx) : ''}
+                        <div class="no-print">
+                            <label class="flex items-center gap-2 text-xs text-slate-500 cursor-pointer">
+                                <input type="checkbox" ${it.usesSub ? 'checked' : ''} class="rounded text-accent focus:ring-accent/50" data-idx="${idx}" data-action="toggleSub">
+                                Use sub-items
+                            </label>
+                        </div>
                     </div>
                 </td>
-                <td class="px-4 py-3 align-top"><input type="number" min="0" value="${it.qty}" ${it.usesSub ? 'disabled' : ''} class="w-24 text-right bg-transparent focus:outline-none disabled:text-slate-400 dark:disabled:text-slate-500" data-idx="${idx}" data-field="qty"></td>
-                <td class="px-4 py-3 align-top"><input type="number" min="0" step="0.01" value="${it.rate}" ${it.usesSub ? 'disabled' : ''} class="w-32 text-right bg-transparent focus:outline-none disabled:text-slate-400 dark:disabled:text-slate-500" data-idx="${idx}" data-field="rate"></td>
-                <td class="px-4 py-3 align-top text-right font-medium text-slate-600 dark:text-slate-300 print:text-gray-800" data-role="line-amount">${fmt(lineAmount(it))}</td>
-                <td class="px-4 py-3 align-top text-center no-print"><button class="text-slate-400 hover:text-red-500" data-action="delItem" data-idx="${idx}">✕</button></td>
+                <td class="item-cell item-cell--qty px-4 py-3 align-top" data-label="Qty">
+                    <input type="number" min="0" value="${it.qty}" ${it.usesSub ? 'disabled' : ''} class="w-full md:w-24 text-right bg-transparent focus:outline-none disabled:text-slate-400 dark:disabled:text-slate-500" data-idx="${idx}" data-field="qty">
+                </td>
+                <td class="item-cell item-cell--rate px-4 py-3 align-top" data-label="Rate">
+                    <input type="number" min="0" step="0.01" value="${it.rate}" ${it.usesSub ? 'disabled' : ''} class="w-full md:w-32 text-right bg-transparent focus:outline-none disabled:text-slate-400 dark:disabled:text-slate-500" data-idx="${idx}" data-field="rate">
+                </td>
+                <td class="item-cell item-cell--amount px-4 py-3 align-top text-right font-medium text-slate-600 dark:text-slate-300 print:text-gray-800" data-label="Amount">
+                    <span class="item-cell__value" data-role="line-amount">${fmt(lineAmount(it))}</span>
+                </td>
+                <td class="item-cell item-cell--actions px-4 py-3 align-top text-center no-print" data-label="Remove">
+                    <button class="text-slate-400 hover:text-red-500" data-action="delItem" data-idx="${idx}">✕</button>
+                </td>
             </tr>
         `).join('');
     }
     
     function renderSubItems(item, itemIdx) {
         const subsHTML = (item.subs || []).map((si, sidx) => `
-            <div class="grid grid-cols-[1fr,auto,auto,auto,auto] gap-2 items-center text-sm">
-                <input class="w-full bg-slate-100 dark:bg-slate-700/50 rounded-md p-1 focus:outline-none focus:ring-1 focus:ring-accent print-bg-transparent" placeholder="Sub-item description" value="${si.desc}" data-idx="${itemIdx}" data-sidx="${sidx}" data-sub-field="desc">
-                <input type="number" min="0" value="${si.qty}" class="w-16 text-right bg-slate-100 dark:bg-slate-700/50 rounded-md p-1 focus:outline-none focus:ring-1 focus:ring-accent print-bg-transparent" data-idx="${itemIdx}" data-sidx="${sidx}" data-sub-field="qty">
-                <input type="number" min="0" step="0.01" value="${si.rate}" class="w-20 text-right bg-slate-100 dark:bg-slate-700/50 rounded-md p-1 focus:outline-none focus:ring-1 focus:ring-accent print-bg-transparent" data-idx="${itemIdx}" data-sidx="${sidx}" data-sub-field="rate">
-                <span class="font-medium text-slate-600 dark:text-slate-300 print:text-gray-700 text-right pr-1" data-role="sub-line-amount">${fmt(toNum(si.qty) * toNum(si.rate))}</span>
-                <button class="text-slate-400 hover:text-red-500 text-xs no-print" data-action="delSubItem" data-idx="${itemIdx}" data-sidx="${sidx}">✕</button>
+            <div class="subitem-card print:bg-transparent print:border-0 print:shadow-none">
+                <div class="subitem-card__header">
+                    <input class="flex-1 bg-white dark:bg-slate-700/50 rounded-md p-2 text-sm focus:outline-none focus:ring-1 focus:ring-accent print-bg-transparent" placeholder="Sub-item description" value="${si.desc}" data-idx="${itemIdx}" data-sidx="${sidx}" data-sub-field="desc">
+                    <button class="text-slate-400 hover:text-red-500 text-xs no-print" data-action="delSubItem" data-idx="${itemIdx}" data-sidx="${sidx}">✕</button>
+                </div>
+                <div class="subitem-card__grid">
+                    <label class="subitem-card__field">
+                        <span class="subitem-card__label">Qty</span>
+                        <input type="number" min="0" value="${si.qty}" class="w-full bg-white dark:bg-slate-700/50 rounded-md p-2 text-right focus:outline-none focus:ring-1 focus:ring-accent print-bg-transparent" data-idx="${itemIdx}" data-sidx="${sidx}" data-sub-field="qty">
+                    </label>
+                    <label class="subitem-card__field">
+                        <span class="subitem-card__label">Rate</span>
+                        <input type="number" min="0" step="0.01" value="${si.rate}" class="w-full bg-white dark:bg-slate-700/50 rounded-md p-2 text-right focus:outline-none focus:ring-1 focus:ring-accent print-bg-transparent" data-idx="${itemIdx}" data-sidx="${sidx}" data-sub-field="rate">
+                    </label>
+                    <div class="subitem-card__field">
+                        <span class="subitem-card__label">Amount</span>
+                        <span class="subitem-card__value" data-role="sub-line-amount">${fmt(toNum(si.qty) * toNum(si.rate))}</span>
+                    </div>
+                </div>
             </div>
         `).join('');
         return `
-            <div class="mt-2 pl-4 border-l-2 border-slate-200 dark:border-slate-600 space-y-2 print:border-gray-200">
+            <div class="subitem-stack print:border-gray-200">
                 ${subsHTML}
-                 <button class="no-print text-xs text-accent dark:text-accent-light font-semibold" data-action="addSubItem" data-idx="${itemIdx}">+ Add sub-item</button>
+                <button class="no-print text-xs text-accent dark:text-accent-light font-semibold" data-action="addSubItem" data-idx="${itemIdx}">+ Add sub-item</button>
             </div>
         `;
     }
@@ -648,6 +902,16 @@ document.addEventListener('DOMContentLoaded', () => {
         $('#total').textContent = fmt(total);
         $('#due').textContent = fmt(due);
 
+        const sync = (sel, val) => {
+            const el = $(sel);
+            if (el) el.textContent = val;
+        };
+        sync('#mobile-subtotal', fmt(subtotal));
+        sync('#mobile-tax', fmt(taxAmt));
+        sync('#mobile-total', fmt(total));
+        sync('#mobile-paid', fmt(totalPaid));
+        sync('#mobile-balance', fmt(due));
+
         // Update individual line item and sub-item amounts in the DOM
         $$('#items tbody tr').forEach((row, i) => {
             const item = state.items[i];
@@ -750,23 +1014,23 @@ document.addEventListener('DOMContentLoaded', () => {
             case 'toggleTheme': toggleTheme(); break;
             case 'setView': setViewMode(target.dataset.view); break;
             case 'addRow':
-                state.items.push(getInitialState().items[0]);
+                state.items.push(createEmptyItem());
                 needsRerender = true;
                 break;
             case 'clearAll':
                 if (confirm('Are you sure you want to clear all items?')) {
-                    state.items = getInitialState().items;
+                    state.items = [createEmptyItem()];
                     needsRerender = true;
                 }
                 break;
             case 'delItem':
                 state.items.splice(idx, 1);
-                if (state.items.length === 0) state.items.push(getInitialState().items[0]);
+                if (state.items.length === 0) state.items.push(createEmptyItem());
                 needsRerender = true;
                 break;
             case 'addSubItem':
                 if (!state.items[idx].subs) state.items[idx].subs = [];
-                state.items[idx].subs.push({ desc: '', qty: 1, rate: 0 });
+                state.items[idx].subs.push(createEmptySubItem());
                 needsRerender = true;
                 break;
             case 'delSubItem':
@@ -774,7 +1038,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 needsRerender = true;
                 break;
             case 'addPayment':
-                state.payments.push({ date: todayISO(), amount: 0, method: 'New Payment' });
+                state.payments.push(createEmptyPayment());
                 needsRerender = true;
                 break;
             case 'delPayment':
@@ -1077,24 +1341,45 @@ document.addEventListener('DOMContentLoaded', () => {
     
     function setViewMode(mode) {
         const container = $('#main-container');
+        if (!container) return;
+
+        const normalized = ['pc', 'tablet', 'mobile'].includes(mode) ? mode : 'pc';
         const viewButtons = $$('[data-action="setView"]');
 
         container.classList.remove('max-w-5xl', 'max-w-3xl', 'max-w-md');
         viewButtons.forEach(btn => btn.classList.remove('bg-white', 'dark:bg-slate-800', 'shadow-sm', 'text-slate-900', 'dark:text-white'));
-        
-        const activeButton = $(`[data-view="${mode}"]`);
-        activeButton.classList.add('bg-white', 'dark:bg-slate-800', 'shadow-sm', 'text-slate-900', 'dark:text-white');
 
-        switch (mode) {
+        const activeButton = $(`[data-view="${normalized}"]`);
+        if (activeButton) {
+            activeButton.classList.add('bg-white', 'dark:bg-slate-800', 'shadow-sm', 'text-slate-900', 'dark:text-white');
+        }
+
+        switch (normalized) {
             case 'tablet': container.classList.add('max-w-3xl'); break;
             case 'mobile': container.classList.add('max-w-md'); break;
             default: container.classList.add('max-w-5xl'); break;
         }
-        storage.set('viewMode', mode);
+
+        document.body.classList.toggle('is-mobile-preview', normalized === 'mobile');
+
+        storage.set('viewMode', normalized);
     }
 
     function applyInitialViewMode() {
         setViewMode(storage.get('viewMode') || 'pc');
+    }
+
+    function watchMobileViewport() {
+        const query = window.matchMedia('(max-width: 640px)');
+        const apply = (event) => {
+            document.body.classList.toggle('is-mobile-width', event.matches);
+        };
+        if (typeof query.addEventListener === 'function') {
+            query.addEventListener('change', apply);
+        } else if (typeof query.addListener === 'function') {
+            query.addListener(apply);
+        }
+        apply(query);
     }
 
     // ---------- Theme Management ----------
@@ -1125,6 +1410,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // ---------- App Initialization ----------
     function init() {
         applyInitialTheme();
+        watchMobileViewport();
         applyInitialViewMode();
         setupDropdowns();
         setupEventListeners();


### PR DESCRIPTION
## Summary
- redesign the invoice editor for small screens with card-style items and a sticky mobile action bar
- add state factory helpers and viewport listeners to harden item management and support mobile preview mode
- refresh sub-item and totals styling for better readability across light and dark themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8634d8c18832e8bccb932806e72ba