### PR TITLE
claude/fix-pdf-attachments-vK5Iu

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,12 +446,12 @@
                 <label for="notes" class="text-xs font-semibold text-slate-500 dark:text-slate-400 print:text-gray-500">Notes</label>
                 <textarea id="notes" class="mt-1 block w-full bg-white dark:bg-slate-900/50 border-slate-300 dark:border-slate-600 rounded-lg shadow-sm text-sm focus:ring-accent focus:border-accent" placeholder="Thanks for your business."></textarea>
               </div>
-              <div class="mt-6 no-print">
-                <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300">Attachments (backed up in Excel)</h3>
+              <div class="mt-6">
+                <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300 print:text-gray-600">Attachments (backed up in Excel)</h3>
                 <div class="mt-2">
-                  <input id="attachPicker" type="file" multiple class="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-accent/10 file:text-accent-dark dark:file:bg-accent/20 dark:file:text-accent-light hover:file:bg-accent/20"/>
+                  <input id="attachPicker" type="file" multiple class="no-print block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-accent/10 file:text-accent-dark dark:file:bg-accent/20 dark:file:text-accent-light hover:file:bg-accent/20"/>
                   <div id="attachments" class="mt-3 space-y-2"></div>
-                  <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">Large files will increase workbook size. PDFs are recommended.</p>
+                  <p class="no-print mt-2 text-xs text-slate-500 dark:text-slate-400">Large files will increase workbook size. PDFs are recommended.</p>
                 </div>
               </div>
             </div>
@@ -1242,12 +1242,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function renderAttachments() {
         const list = $('#attachments');
         list.innerHTML = state.attachments.map((a, i) => `
-            <div class="flex items-center justify-between gap-3 p-2 rounded-lg bg-slate-100 dark:bg-slate-700/50 text-sm">
+            <div class="flex items-center justify-between gap-3 p-2 rounded-lg bg-slate-100 dark:bg-slate-700/50 text-sm print:bg-gray-50">
                 <div class="truncate">
-                    <strong class="font-medium text-slate-700 dark:text-slate-200">${a.filename}</strong> 
-                    <span class="text-slate-500 dark:text-slate-400 text-xs">(${a.mime}, ${Math.round(a.size/1024)} KB)</span>
+                    <strong class="font-medium text-slate-700 dark:text-slate-200 print:text-gray-700">${a.filename}</strong>
+                    <span class="text-slate-500 dark:text-slate-400 text-xs print:text-gray-500">(${a.mime}, ${Math.round(a.size/1024)} KB)</span>
                 </div>
-                <button class="text-slate-400 hover:text-red-500" data-action="delAttachment" data-idx="${i}">✕</button>
+                <button class="no-print text-slate-400 hover:text-red-500" data-action="delAttachment" data-idx="${i}">✕</button>
             </div>
         `).join('');
     }


### PR DESCRIPTION
Previously, attachments were hidden from PDF exports due to the no-print CSS class on the attachments section. This fix:

- Removes no-print from the attachments container to make them visible in PDFs
- Hides interactive elements (file picker, delete buttons, help text) from print
- Adds print-specific styling for better contrast in PDFs

Users can now see their uploaded attachments when exporting to PDF.

Fixes issue where attachments wouldn't appear in PDF exports.