### PR TITLE
Fix: Handle expired Google OAuth tokens gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,7 +610,18 @@ document.addEventListener('DOMContentLoaded', () => {
             googleAuth.userInfo = JSON.parse(savedUserInfo);
             googleAuth.isSignedIn = true;
             initGapi().then(() => {
+                // Verify that folder ID was successfully retrieved
+                if (!googleAuth.folderId) {
+                    console.warn('Failed to retrieve folder ID, session may be expired');
+                    signOut();
+                    showNotification('Session expired. Please sign in again.', 'warn');
+                    return;
+                }
                 showAuthenticatedUI();
+            }).catch((error) => {
+                console.error('Error restoring session:', error);
+                signOut();
+                showNotification('Session expired. Please sign in again.', 'warn');
             });
         }
     }
@@ -746,6 +757,12 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        if (!googleAuth.folderId) {
+            showNotification('Drive folder not initialized. Please sign in again.', 'error');
+            signOut();
+            return;
+        }
+
         try {
             updateSyncStatus('syncing', 'Saving...');
 
@@ -804,6 +821,12 @@ document.addEventListener('DOMContentLoaded', () => {
     async function loadFromDrive() {
         if (!googleAuth.isSignedIn) {
             showNotification('Please sign in to load from Google Drive', 'warn');
+            return;
+        }
+
+        if (!googleAuth.folderId) {
+            showNotification('Drive folder not initialized. Please sign in again.', 'error');
+            signOut();
             return;
         }
 
@@ -883,7 +906,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     async function autoLoadFromDrive() {
-        if (!googleAuth.isSignedIn) return;
+        if (!googleAuth.isSignedIn || !googleAuth.folderId) return;
 
         try {
             const response = await gapi.client.drive.files.list({


### PR DESCRIPTION
Previously, when OAuth tokens expired and the app tried to restore a session from sessionStorage, it would:
- Fail to retrieve the Drive folder ID
- Show as "authenticated" but with null folderId
- Cause 401 errors when trying to access Drive API

This fix adds proper error handling:
- Validates that folderId was successfully retrieved after session restore
- Detects expired/invalid tokens and prompts user to sign in again
- Adds safety checks in saveToDrive, loadFromDrive, and autoLoadFromDrive
- Prevents API calls with null folderId

Users will now be automatically signed out if their session has expired, with a clear notification to sign in again.

Fixes 401 Unauthorized errors when using Google Drive integration.