### PR TITLE
claude/fix-pdf-attachments-TxmYP

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,13 +446,13 @@
                 <label for="notes" class="text-xs font-semibold text-slate-500 dark:text-slate-400 print:text-gray-500">Notes</label>
                 <textarea id="notes" class="mt-1 block w-full bg-white dark:bg-slate-900/50 border-slate-300 dark:border-slate-600 rounded-lg shadow-sm text-sm focus:ring-accent focus:border-accent" placeholder="Thanks for your business."></textarea>
               </div>
-              <div class="mt-6 no-print">
-                <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300">Attachments (backed up in Excel)</h3>
-                <div class="mt-2">
+              <div class="mt-6">
+                <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300 print:text-gray-500">Attachments</h3>
+                <div class="mt-2 no-print">
                   <input id="attachPicker" type="file" multiple class="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-accent/10 file:text-accent-dark dark:file:bg-accent/20 dark:file:text-accent-light hover:file:bg-accent/20"/>
-                  <div id="attachments" class="mt-3 space-y-2"></div>
                   <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">Large files will increase workbook size. PDFs are recommended.</p>
                 </div>
+                <div id="attachments" class="mt-3 space-y-2"></div>
               </div>
             </div>
             <!-- Totals Section -->
@@ -1242,12 +1242,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function renderAttachments() {
         const list = $('#attachments');
         list.innerHTML = state.attachments.map((a, i) => `
-            <div class="flex items-center justify-between gap-3 p-2 rounded-lg bg-slate-100 dark:bg-slate-700/50 text-sm">
+            <div class="flex items-center justify-between gap-3 p-2 rounded-lg bg-slate-100 dark:bg-slate-700/50 print:bg-white print:border print:border-slate-300 text-sm">
                 <div class="truncate">
-                    <strong class="font-medium text-slate-700 dark:text-slate-200">${a.filename}</strong> 
-                    <span class="text-slate-500 dark:text-slate-400 text-xs">(${a.mime}, ${Math.round(a.size/1024)} KB)</span>
+                    <strong class="font-medium text-slate-700 dark:text-slate-200 print:text-gray-800">${a.filename}</strong>
+                    <span class="text-slate-500 dark:text-slate-400 text-xs print:text-gray-600">(${a.mime}, ${Math.round(a.size/1024)} KB)</span>
                 </div>
-                <button class="text-slate-400 hover:text-red-500" data-action="delAttachment" data-idx="${i}">✕</button>
+                <button class="no-print text-slate-400 hover:text-red-500" data-action="delAttachment" data-idx="${i}">✕</button>
             </div>
         `).join('');
     }


### PR DESCRIPTION
Previously, the entire attachments section was hidden in print/PDF export due to the no-print class on the parent container. This fix:
- Removes no-print from the attachments section container
- Adds no-print only to the file picker and help text
- Hides delete buttons in print view with no-print class
- Adds proper print styling to attachment cards (white bg, border, proper colors)

Now attachments will be visible when users export to PDF, showing the filename, mime type, and file size for each attachment.